### PR TITLE
Add >> operator for variables

### DIFF
--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -120,6 +120,15 @@ public struct Variable<Value: Equatable> {
     }
 }
 
+prefix operator >>
+
+extension Variable {
+    static func >>(_ variable: Variable, _ list: inout [Variable]) -> Variable {
+        list.append(variable)
+        return variable
+    }
+}
+
 extension Variable: VariableProtocol {
     public var property: Property<Value> {
         return Property(self, { $0 })

--- a/Tests/LogicianTests/VariableTests.swift
+++ b/Tests/LogicianTests/VariableTests.swift
@@ -19,6 +19,12 @@ class VariableTests: XCTestCase {
         XCTAssertFalse(var2 == var3)
     }
 
+    func testAppendOperator() {
+        var list = [Variable<Int>]()
+        let variable = Variable() >> list
+        XCTAssertTrue(list.first! == variable)
+    }
+
     static var allTests: [(String, (VariableTests) -> () throws -> Void)] {
         return [
             ("testIdentity", testIdentity),

--- a/Tests/XCTestManifests.swift
+++ b/Tests/XCTestManifests.swift
@@ -94,6 +94,7 @@ extension StateTests {
 
 extension VariableTests {
     static let __allTests = [
+        ("testAppendOperator", testAppendOperator),
         ("testIdentity", testIdentity),
     ]
 }


### PR DESCRIPTION
I added this operator which IMO comes handy when you need to add constraints to a specific variable. Now you can write:
```
let x1 = Variable() >> list
let x2 = Variable() >> list
let x3 = Variable() >> list
```

instead of:
```
let x1 = Variable()
list.append(x1)
let x2 = Variable()
list.append(x2)
let x3 = Variable()
list.append(x3)
```

The operator just adds the Variable to the list and returns the Variable, so you can assign it to a swift property in a single line.

